### PR TITLE
Removed a new line before of the return statement

### DIFF
--- a/common/widgets/LanguageDropdown.php
+++ b/common/widgets/LanguageDropdown.php
@@ -25,7 +25,6 @@ class LanguageDropdown extends Widget{
             $this->setSelectedLanguage($localeId, $currentLanguage);
         }
         $this->returnToCurrentLanguage($currentLanguage);
-
         return $this->render('_language-dropdown', ['supportedLanguages'=>$this->supportedLanguages,
                                                     'selectedLanguage'=>$this->selectedLanguage]);
     }


### PR DESCRIPTION
All return are without a new line except this return. We do not want this evil return in the source code.
